### PR TITLE
Use $app to get the current user

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,7 +635,7 @@ if (is_object($fileNode)) $fileNode->move($folder);
 
 #### Get/Check current user
 ```PHP
-$u = new User();
+$u = $app->make(\Concrete\Core\User\User::class);
 
 if ($u->isRegistered()) {
     print 'User is logged in.';


### PR DESCRIPTION
Currently

```php
$u = new User();
```
and
```php
$u = $app->make(User::class);
```

are almost the same.

BTW, because https://github.com/concrete5/concrete5/pull/7433 has been merged into the core, using the `$app->make(User::class)` approach will be faster than using `new User()` starting from concrete5 version 8.6, so it's worth using that approach.