### PR TITLE
concrete5 is always lowercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# [Concrete5](https://www.concrete5.org) Cheat Sheet V8+
+# [concrete5](https://www.concrete5.org) Cheat Sheet V8+
 
-This is a collection of Concrete5 cheat sheets, based on the C5 V8+ source code. 
+This is a collection of concrete5 cheat sheets, based on the C5 V8+ source code. 
 
 **Contributions are welcome via [issues](https://github.com/shahroq/whale_c5_cheat_sheet/issues) and [pull requests](https://github.com/shahroq/whale_c5_cheat_sheet/pulls).**
 


### PR DESCRIPTION
Even in titles and at beginning of sentences.